### PR TITLE
Mastodon publisher fixes

### DIFF
--- a/botfriend/publish/_mastodon.py
+++ b/botfriend/publish/_mastodon.py
@@ -31,7 +31,7 @@ class MastodonPublisher(Publisher):
         # credentials to the wrong account.
         verification = self.api.account_verify_credentials()
         if 'username' in verification:
-            return ['username']
+            return verification['username']
         else:
             # error
             raise Exception(repr(verification))

--- a/botfriend/publish/_mastodon.py
+++ b/botfriend/publish/_mastodon.py
@@ -23,6 +23,7 @@ class MastodonPublisher(Publisher):
             access_token = instance['access_token'],
             api_base_url = url
         )
+        self.max_chars = instance.get('max_chars', 500)
 
     def self_test(self):
         # Do something that will raise an exception if the credentials are invalid.
@@ -68,7 +69,7 @@ class MastodonPublisher(Publisher):
         # some cases the maximum length might be different.
         if isinstance(content, str):
             content = content.encode("utf8")
-        return content[:500]
+        return content[:int(self.max_chars)]
 
 
 Publisher = MastodonPublisher


### PR DESCRIPTION
Two individual fixes/improvements for the mastodon publisher:

1) show the username when testing the publisher, instead of printing 'username'
2) allow mastodon max chars to be configurable in bot.yaml. will default to 500